### PR TITLE
文件名不应包含完整文件路径

### DIFF
--- a/PasteEx/Core/Processor/TextProcessor.cs
+++ b/PasteEx/Core/Processor/TextProcessor.cs
@@ -83,6 +83,7 @@ namespace PasteEx.Core.Processor
                     ResultObject = Data.Storage.GetData(DataFormats.Text);
                 }
             }
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
             File.WriteAllText(path, ResultObject as string, new UTF8Encoding(false));
             OnSaveAsFileCompleted();
             return true;

--- a/PasteEx/Forms/FormSetting.cs
+++ b/PasteEx/Forms/FormSetting.cs
@@ -446,26 +446,9 @@ namespace PasteEx.Forms
 
         private void txtFileNamePattern_TextChanged(object sender, EventArgs e)
         {
-            // 合法性检测并输出到预览
-            // Path.GetInvalidFileNameChars() eq [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 34, 60, 62, 124, 58, 42, 63, 92, 47]
-            char[] InvalidFileNameChars = { '\0', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07', '\x08', '\t', '\n', '\x0b', '\x0c', '\r', '\x0e', '\x0f', '\x10', '\x11', '\x12', '\x13', '\x14', '\x15', '\x16', '\x17', '\x18', '\x19', '\x1a', '\x1b', '\x1c', '\x1d', '\x1e', '\x1f', '"', '<', '>', '|', ':', '*', '?', '/' };
-            int lastSplitCharIndex = txtFileNamePattern.Text.LastIndexOf('\\') + 1;
-            string folder, filename;
-            if (lastSplitCharIndex >= 0)
-            {
-                folder = txtFileNamePattern.Text.Substring(0, lastSplitCharIndex);
-                filename = txtFileNamePattern.Text.Substring(lastSplitCharIndex, txtFileNamePattern.Text.Length - lastSplitCharIndex);
-                Settings.Default.fileNameFolder = folder;
-                Settings.Default.fileNamePattern = folder.EndsWith("\\") ? folder : folder + "\\" + filename;
-                Settings.Default.fileNamePatternPure = filename;
-            }
-            else
-            {
-                filename = txtFileNamePattern.Text;
-                folder = "";
-            }
-
-            if (filename.IndexOfAny(InvalidFileNameChars) >= 0)
+            char[] InvalidPathChars = Path.GetInvalidPathChars();
+            string relativePath = txtFileNamePattern.Text;
+            if (relativePath.IndexOfAny(InvalidPathChars) >= 0)
             {
                 lblPreviewResult.Text = Resources.Strings.TipInvalidFileNameChars;
             }
@@ -473,7 +456,7 @@ namespace PasteEx.Forms
             {
                 try
                 {
-                    lblPreviewResult.Text = PathGenerator.GenerateDefaultFileName(folder, filename);
+                    lblPreviewResult.Text = PathGenerator.GenerateDefaultRelativePath(relativePath);
                 }
                 catch (Exception ex)
                 {

--- a/PasteEx/Properties/Settings.Designer.cs
+++ b/PasteEx/Properties/Settings.Designer.cs
@@ -132,7 +132,7 @@ namespace PasteEx.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("$yyyyMMdd$\\\\Clip_$HHmmss$")]
+        [global::System.Configuration.DefaultSettingValueAttribute("$yyyyMMdd$\\Clip_$HHmmss$")]
         public string fileNamePattern {
             get {
                 return ((string)(this["fileNamePattern"]));
@@ -199,30 +199,6 @@ namespace PasteEx.Properties {
             }
             set {
                 this["ApplicationFilterExclude"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string fileNameFolder {
-            get {
-                return ((string)(this["fileNameFolder"]));
-            }
-            set {
-                this["fileNameFolder"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string fileNamePatternPure {
-            get {
-                return ((string)(this["fileNamePatternPure"]));
-            }
-            set {
-                this["fileNamePatternPure"] = value;
             }
         }
     }


### PR DESCRIPTION
- 目前（官方仓库最新代码），“文件名”一项包括完整文件路径，如果点击save，则会出现错误`System.NotSupportedException: 'The given path's format is not supported.'`。本PR将其修复。
![image](https://github.com/user-attachments/assets/556a47d9-37e2-4565-8229-e4ee3a43d1cc)
- 使用Path.Combine，增强可维护性